### PR TITLE
Remove references and status/health checks for ha-bridge

### DIFF
--- a/sandman_web/status/status.py
+++ b/sandman_web/status/status.py
@@ -64,36 +64,6 @@ def _check_rhasspy_health() -> _HealthType:
         return _HealthType.NOT_RUNNING
 
 
-def _check_ha_bridge_health() -> _HealthType:
-    """Check that ha-bridge is running and responding.
-
-    Returns a status code based on container status and http request response.
-    """
-    # Get the ha-bridge contatiner status
-    client = docker.DockerClient(base_url="unix://var/run/docker.sock")
-    try:
-        container = client.containers.get("ha-bridge")
-    except Exception:
-        # ha-bridge may not be installed on host
-        return _HealthType.NOT_FOUND
-    else:
-        container_status = container.attrs["State"]["Status"]
-
-    # Get the ha-bridge web response
-    try:
-        web_response = requests.get("http://localhost:80")
-    except Exception:
-        web_status = 404
-    else:
-        web_status = web_response.status_code
-
-    # Check that the ha-bridge container is running or the web response is OK
-    if container_status == "running" or web_status == 200:
-        return _HealthType.RUNNING
-    else:
-        return _HealthType.NOT_RUNNING
-
-
 def is_healthy() -> bool:
     """Return whether the status is healthy overall."""
     sandman_health = _check_sandman_health()
@@ -117,7 +87,6 @@ def status_home() -> str:
     # Perform the Sandman related health checks.
     sandman_health = _check_sandman_health()
     rhasspy_health = _check_rhasspy_health()
-    ha_bridge_health = _check_ha_bridge_health()
 
     # Check that Sandman is in good health.
     if sandman_health == _HealthType.RUNNING:
@@ -133,20 +102,8 @@ def status_home() -> str:
         if rhasspy_health == _HealthType.NOT_FOUND:
             rhasspy_status += "The Rhasspy container may not exist."
 
-    # Check that ha-bridge is in good health
-    if ha_bridge_health == _HealthType.RUNNING:
-        ha_bridge_status = "ha-bridge is running. ✔️"
-    else:
-        ha_bridge_status = "ha-bridge is not running. ❌"
-        if ha_bridge_health == _HealthType.NOT_FOUND:
-            ha_bridge_status += (
-                "ha-bridge may not be installed on the host as a container "
-                "or is otherwise unresponsive."
-            )
-
     return render_template(
         "status.html",
         sandman_status=sandman_status,
-        rhasspy_status=rhasspy_status,
-        ha_bridge_status=ha_bridge_status,
+        rhasspy_status=rhasspy_status
     )

--- a/sandman_web/status/status.py
+++ b/sandman_web/status/status.py
@@ -105,5 +105,5 @@ def status_home() -> str:
     return render_template(
         "status.html",
         sandman_status=sandman_status,
-        rhasspy_status=rhasspy_status
+        rhasspy_status=rhasspy_status,
     )

--- a/sandman_web/status/templates/status.html
+++ b/sandman_web/status/templates/status.html
@@ -7,6 +7,5 @@
 {% block content %}
 <h2>Sandman</h2> {{ sandman_status }}
 <h2>Rhasspy</h2> {{ rhasspy_status }}
-<h2>ha-bridge</h2> {{ ha_bridge_status }}
 
 {% endblock %}


### PR DESCRIPTION
ha-bridge is to be replaced by something else so I went ahead and removed the the status/health checks for ha-bridge from the status page.